### PR TITLE
Make dispatcher not replan in every simulation step

### DIFF
--- a/src/main/java/ch/ethz/matsim/av/dispatcher/single_heuristic/SingleHeuristicDispatcher.java
+++ b/src/main/java/ch/ethz/matsim/av/dispatcher/single_heuristic/SingleHeuristicDispatcher.java
@@ -112,6 +112,7 @@ public class SingleHeuristicDispatcher implements AVDispatcher {
         
         if (reoptimize && now >= nextReplanningTimestamp) {
         	reoptimize(now);
+        	reoptimize = false;
         	nextReplanningTimestamp = now + replanningInterval;
         }
     }


### PR DESCRIPTION
Before `replanning` was never set to `false`